### PR TITLE
feat: Add docker-compose for local dev workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .vscode/
 node_modules/
+
+# (Docker) database volume data
+.database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.5'
+
+services:
+  postgres:
+    image: postgres
+    ports:
+      - 5437:5432
+    environment:
+      POSTGRES_PASSWORD: docker
+      POSTGRES_USER: postgres
+      POSTGRES_DB: codesprint
+    volumes:
+      - ./.database:/var/lib/postgresql/data

--- a/ormconfig.json
+++ b/ormconfig.json
@@ -1,7 +1,7 @@
 {
   "type": "postgres",
   "host": "localhost",
-  "port": 5432,
+  "port": 5437,
   "username": "postgres",
   "password": "docker",
   "database": "codesprint",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "build": "tsc",
+		"build": "tsc",
+		"predev:server": "docker-compose up -d",
 		"dev:server": "ts-node-dev --inspect --transpile-only --ignore-watch node_modules src/server.ts",
 		"typeorm": "ts-node ./node_modules/typeorm/cli.js"
   },


### PR DESCRIPTION
Now just run `dev:server` and the Postgres instance should be initialized before.
Of course, you need to have installed [docker-compose](https://docs.docker.com/compose/)