### PR TITLE
Fix: eslintrc.json naming conventions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,12 +27,43 @@
     "prettier/prettier": "error",
     "class-methods-use-this": "off",
     "no-useless-constructor": "off",
-    "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/no-unused-vars": ["error", {
       "argsIgnorePattern": "_$"
-    }],
-		"@typescript-eslint/naming-convention": ["error", { "prefixWithI": "always"	}],
-    "import/extensions": [
+		}],
+		"camelcase": "off",
+		"@typescript-eslint/naming-convention":  [
+			"error",
+			{
+				"selector": "default",
+				"format": ["camelCase"]
+			},
+			{
+				"selector": "variable",
+				"format": ["camelCase", "snake_case"]
+			},
+			{
+				"selector": "parameter",
+				"format": ["camelCase", "snake_case"],
+				"leadingUnderscore": "allow"
+			},
+			{
+				"selector": "typeLike",
+				"format": ["PascalCase"]
+			},
+			{
+				"selector": "property",
+				"format": ["camelCase", "snake_case"]
+			},
+			{
+				"selector": "interface",
+				"format": ["PascalCase"],
+				"custom": {
+					"regex": "^I[A-Z]",
+					"match": true
+				}
+			}
+		],
+		"import/extensions": [
       "error",
       "ignorePackages",
       {


### PR DESCRIPTION
I noticed ESLint was not working properly because "@typescript-eslint/camelcase" rule was deprecated and the syntax for @typescript-eslint/naming-convention rules was changed.

Both rules are now combined, so I updated @typescript-eslint/naming-convention to reflect that