### PR TITLE
Fix: Turned off ESLint prefer-default-export rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -63,6 +63,7 @@
 				}
 			}
 		],
+		"import/prefer-default-export": "off",
 		"import/extensions": [
       "error",
       "ignorePackages",


### PR DESCRIPTION
The prefer-default-export ESLint rule was conflicting with our code, because we are using named exports. Since we agreed that we would prefer named exports over default exports on our previous discord talk I turned this rule off.

<img alt="estlint prefer-default-export rule causing conflict" src="https://user-images.githubusercontent.com/60204789/94108644-aa18bf80-fe0d-11ea-8500-f83a90dc5f5e.png" width="500" />